### PR TITLE
feat(amm): prevents buy & sells if event is ongoing

### DIFF
--- a/amm/src/contract.rs
+++ b/amm/src/contract.rs
@@ -120,7 +120,7 @@ impl Market {
         payload: BuyArgs,
     ) -> WrappedBalance {
         self.assert_is_published();
-        self.assert_is_not_over();
+        self.assert_is_open();
         self.assert_is_not_resolved();
 
         let mut outcome_token = self.get_outcome_token(payload.outcome_id);
@@ -182,6 +182,10 @@ impl Market {
         }
 
         if !self.is_resolved() {
+            if self.is_closed() && !self.is_over() {
+                env::panic_str("ERR_SELL_MARKET_IS_CLOSED_FOR_SELLS_UNTIL_RESOLUTION");
+            }
+
             self.assert_is_not_under_resolution();
         }
 

--- a/amm/src/modifiers.rs
+++ b/amm/src/modifiers.rs
@@ -23,8 +23,8 @@ impl Market {
     }
 
     pub fn assert_in_stand_by(&self) {
-        if self.is_open() {
-            env::panic_str("ERR_MARKET_IS_OPEN");
+        if self.has_begun() {
+            env::panic_str("ERR_EVENT_HAS_STARTED");
         }
     }
 
@@ -41,12 +41,6 @@ impl Market {
     pub fn assert_is_open(&self) {
         if !self.is_open() {
             env::panic_str("ERR_MARKET_IS_CLOSED");
-        }
-    }
-
-    pub fn assert_is_not_over(&self) {
-        if self.is_over() {
-            env::panic_str("ERR_EVENT_IS_OVER");
         }
     }
 

--- a/amm/src/views.rs
+++ b/amm/src/views.rs
@@ -82,13 +82,27 @@ impl Market {
         }
     }
 
+    /**
+     * A market is open (buys and sells are enabled) 3/4 before the event ends
+     * the reason being that users should not buy or sell 1 minute before the outcome becomes evident
+     */
     pub fn is_open(&self) -> bool {
-        self.market.starts_at < self.get_block_timestamp()
-            && self.market.ends_at >= self.get_block_timestamp()
+        let diff = (self.market.ends_at - self.market.starts_at) as f64 * 0.75;
+        let limit = self.market.ends_at - diff as i64;
+
+        self.get_block_timestamp() <= limit
+    }
+
+    pub fn is_closed(&self) -> bool {
+        !self.is_open()
     }
 
     pub fn is_over(&self) -> bool {
         self.get_block_timestamp() > self.market.ends_at
+    }
+
+    pub fn has_begun(&self) -> bool {
+        self.get_block_timestamp() > self.market.starts_at
     }
 
     pub fn is_resolution_window_expired(&self) -> bool {

--- a/amm/src/views.rs
+++ b/amm/src/views.rs
@@ -82,13 +82,18 @@ impl Market {
         }
     }
 
+    pub fn get_buy_sell_timestamp(&self) -> i64 {
+        let diff = (self.market.ends_at - self.market.starts_at) as f64 * 0.75;
+
+        self.market.ends_at - diff as i64
+    }
+
     /**
      * A market is open (buys and sells are enabled) 3/4 before the event ends
      * the reason being that users should not buy or sell 1 minute before the outcome becomes evident
      */
     pub fn is_open(&self) -> bool {
-        let diff = (self.market.ends_at - self.market.starts_at) as f64 * 0.75;
-        let limit = self.market.ends_at - diff as i64;
+        let limit = self.get_buy_sell_timestamp();
 
         self.get_block_timestamp() <= limit
     }


### PR DESCRIPTION
If an event has started, users should be able to buy & sell only `3/4 time` before the event ends.
It doesn't make sense to bet on an event that is about to end because the outcome may become evident. 