### PR TITLE
refactor(AMM): remove publish after start_date rule

### DIFF
--- a/amm/src/contract.rs
+++ b/amm/src/contract.rs
@@ -76,7 +76,6 @@ impl Market {
     #[payable]
     pub fn publish(&mut self) -> Promise {
         self.assert_is_not_published();
-        self.assert_in_stand_by();
 
         let mut outcome_id = 0;
         let options = &self.market.options.clone();

--- a/amm/src/modifiers.rs
+++ b/amm/src/modifiers.rs
@@ -22,12 +22,6 @@ impl Market {
         }
     }
 
-    pub fn assert_in_stand_by(&self) {
-        if self.has_begun() {
-            env::panic_str("ERR_EVENT_HAS_STARTED");
-        }
-    }
-
     pub fn assert_price_constant(&self) {
         let mut k: Price = 0.0;
 

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -469,31 +469,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "ERR_EVENT_HAS_STARTED")]
-    fn test_publish_error_after_event_starts() {
-        let mut context = setup_context();
-
-        let now = Utc::now();
-        testing_env!(context.block_timestamp(block_timestamp(now)).build());
-        let starts_at = now - Duration::hours(1);
-        let ends_at = starts_at + Duration::hours(1);
-        let resolution_window = ends_at + Duration::hours(3);
-        let claiming_window = resolution_window + Duration::days(3);
-
-        let market_data: MarketData = create_market_data(
-            "a market description".to_string(),
-            2,
-            date(starts_at),
-            date(ends_at),
-        );
-
-        let mut contract: Market =
-            setup_contract(market_data, date(resolution_window), date(claiming_window));
-
-        publish(&mut contract, &context);
-    }
-
-    #[test]
     #[should_panic(expected = "ERR_MARKET_IS_CLOSED")]
     fn test_buy_error_if_event_is_ongoing() {
         let mut context = setup_context();


### PR DESCRIPTION
Remove rule that prevents publishing the market after the event starts.