### PR TITLE
Implement market self destruct

### DIFF
--- a/amm/src/contract.rs
+++ b/amm/src/contract.rs
@@ -228,6 +228,19 @@ impl Market {
             .aggregator_read(msg.to_string())
     }
 
+    /**
+     * Deletes the Market contract account after the market window has ended.
+     *
+     * Anyone may call this once the market is over. NEAR sends the remaining
+     * storage balance on the deleted contract account to the market creator.
+     */
+    pub fn self_destruct(&mut self) -> Promise {
+        near_sdk::require!(self.is_over(), "ERR_MARKET_WINDOW_NOT_OVER");
+
+        Promise::new(env::current_account_id())
+            .delete_account(self.management.market_creator_account_id.clone())
+    }
+
     #[private]
     pub fn update_ct_balance(&mut self, amount: WrappedBalance) -> WrappedBalance {
         log!(

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -2,8 +2,9 @@
 mod tests {
     use crate::storage::*;
     use chrono::{Duration, Utc};
+    use near_sdk::mock::VmAction;
     use near_sdk::test_utils::test_env::{alice, bob, carol};
-    use near_sdk::test_utils::VMContextBuilder;
+    use near_sdk::test_utils::{get_created_receipts, VMContextBuilder};
     use near_sdk::{testing_env, AccountId, Balance, PromiseResult};
     use rand::seq::SliceRandom;
 
@@ -43,6 +44,10 @@ mod tests {
 
     fn market_creator_account_id() -> AccountId {
         AccountId::new_unchecked("market_creator_account_id.near".to_string())
+    }
+
+    fn market_account_id() -> AccountId {
+        AccountId::new_unchecked("market.near".to_string())
     }
 
     fn date(date: chrono::DateTime<chrono::Utc>) -> i64 {
@@ -673,6 +678,67 @@ mod tests {
         create_outcome_tokens(&mut contract);
 
         contract.aggregator_read();
+    }
+
+    #[test]
+    #[should_panic(expected = "ERR_MARKET_WINDOW_NOT_OVER")]
+    fn self_destruct_errors_before_market_window_is_over() {
+        let mut context = setup_context();
+
+        let now = Utc::now();
+        testing_env!(context.block_timestamp(block_timestamp(now)).build());
+        let starts_at = now + Duration::hours(1);
+        let ends_at = starts_at + Duration::hours(1);
+
+        let market_data: MarketData = create_market_data(
+            "a market description".to_string(),
+            2,
+            date(starts_at),
+            date(ends_at),
+        );
+
+        let mut contract: Market = setup_contract(market_data, None);
+
+        contract.self_destruct();
+    }
+
+    #[test]
+    fn self_destruct_returns_storage_deposit_to_market_creator_after_market_window() {
+        let mut context = setup_context();
+
+        let now = Utc::now();
+        testing_env!(context.block_timestamp(block_timestamp(now)).build());
+        let starts_at = now - Duration::hours(2);
+        let ends_at = now - Duration::hours(1);
+
+        let market_data: MarketData = create_market_data(
+            "a market description".to_string(),
+            2,
+            date(starts_at),
+            date(ends_at),
+        );
+
+        let mut contract: Market = setup_contract(market_data, None);
+
+        testing_env!(context
+            .current_account_id(market_account_id())
+            .predecessor_account_id(frank())
+            .signer_account_id(frank())
+            .block_timestamp(block_timestamp(now))
+            .build());
+
+        contract.self_destruct();
+
+        let receipts = get_created_receipts();
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].receiver_id, market_account_id());
+        assert_eq!(receipts[0].actions.len(), 1);
+        assert_eq!(
+            receipts[0].actions[0],
+            VmAction::DeleteAccount {
+                beneficiary_id: market_creator_account_id()
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #31

## Summary
- Add a public `self_destruct` method for Market contracts.
- Gate account deletion until the market window is over.
- Delete the current Market contract account with the market creator as the beneficiary, returning remaining storage balance to `management.market_creator_account_id`.
- Add focused tests for the timing guard and the delete-account beneficiary receipt.

## Validation
- `cargo fmt -- --check` in `amm`
- `cargo check` in `amm`
- `cargo test self_destruct -- --test-threads=1` in `amm`
- `git diff --check`

Note: the full local `cargo test` suite still aborts in pre-existing `#[should_panic]` tests that call `env::panic_str` directly under this local Rust/near-sdk test runtime. The new `self_destruct` tests pass directly.

## Payout
USDT on Polygon PoS: 0xE7201960FEa5bFF7Ae4Fe3286093dCedabeDB003
