### PR TITLE
Document contract methods

### DIFF
--- a/amm/src/callbacks.rs
+++ b/amm/src/callbacks.rs
@@ -7,6 +7,7 @@ use crate::{storage::*, FORMATTED_STRING_LOCALE};
 #[near_bindgen]
 impl Market {
     #[private]
+    /// Applies a successful collateral transfer callback by burning sold outcome tokens and reducing collateral balance.
     pub fn on_ft_transfer_callback(
         &mut self,
         amount: WrappedBalance,

--- a/amm/src/contract.rs
+++ b/amm/src/contract.rs
@@ -13,6 +13,7 @@ use crate::storage::*;
 
 #[ext_contract(ext_self)]
 trait Callbacks {
+    /// Finalizes an outcome-token sale after the collateral transfer returns.
     fn on_ft_transfer_callback(
         &mut self,
         amount: WrappedBalance,
@@ -24,10 +25,12 @@ trait Callbacks {
 
 #[ext_contract(ext_feed_parser)]
 trait SwitchboardFeedParser {
+    /// Requests the feed-parser contract to read an encoded aggregator message.
     fn aggregator_read(&self, msg: String) -> Promise;
 }
 
 impl Default for Market {
+    /// Prevents creating an uninitialized market with the Rust default value.
     fn default() -> Self {
         env::panic_str("ERR_MARKET_NOT_INITIALIZED")
     }
@@ -36,6 +39,7 @@ impl Default for Market {
 #[near_bindgen]
 impl Market {
     #[init]
+    /// Initializes a market with metadata, resolution rules, management accounts, fees, and optional price data.
     pub fn new(
         market: MarketData,
         resolution: Resolution,
@@ -193,6 +197,7 @@ impl Market {
         self.resolution.resolved_at = Some(self.get_block_timestamp());
     }
 
+    /// Creates one inactive-balance outcome token for each configured market option.
     pub fn create_outcome_tokens(&mut self) -> usize {
         match self.outcome_tokens.get(&0) {
             Some(_token) => env::panic_str("ERR_CREATE_OUTCOME_TOKENS_OUTCOMES_EXIST"),
@@ -229,6 +234,7 @@ impl Market {
     }
 
     #[private]
+    /// Replaces the tracked collateral-token balance after collateral enters or leaves the market.
     pub fn update_ct_balance(&mut self, amount: WrappedBalance) -> WrappedBalance {
         log!(
             "update_ct_balance: {}",
@@ -240,6 +246,7 @@ impl Market {
     }
 
     #[private]
+    /// Adds newly collected fees to the tracked collateral-token fee balance.
     pub fn update_ct_fee_balance(&mut self, amount: WrappedBalance) -> WrappedBalance {
         self.collateral_token.fee_balance += amount;
         self.collateral_token.fee_balance
@@ -247,6 +254,7 @@ impl Market {
 }
 
 impl Market {
+    /// Deactivates every losing outcome token after the winning outcome is known.
     fn burn_the_losers(&mut self, outcome_id: OutcomeId) {
         for id in 0..self.market.options.len() {
             let mut outcome_token = self.get_outcome_token(id as OutcomeId);
@@ -258,11 +266,13 @@ impl Market {
         }
     }
 
+    /// Creates and stores an empty outcome token for the given market outcome.
     fn create_outcome_token(&mut self, outcome_id: OutcomeId) {
         let outcome_token = OutcomeToken::new(outcome_id, 0);
         self.outcome_tokens.insert(&outcome_id, &outcome_token);
     }
 
+    /// Burns a seller's outcome tokens and starts the collateral payout transfer.
     fn internal_sell(&mut self, outcome_id: OutcomeId, amount: WrappedBalance) -> WrappedBalance {
         if amount > self.balance_of(outcome_id, env::signer_account_id()) {
             env::panic_str("ERR_SELL_AMOUNT_GREATER_THAN_BALANCE");

--- a/amm/src/fees.rs
+++ b/amm/src/fees.rs
@@ -9,8 +9,11 @@ use crate::storage::*;
 
 #[ext_contract(ext_self)]
 trait Callbacks {
+    /// Records a successful market-creator fee payout.
     fn on_claim_market_creator_fees_resolved_callback(&mut self, payee: AccountId) -> String;
+    /// Continues DAO fee sweeping after the collateral token balance is returned.
     fn on_ft_balance_of_market_callback(&mut self) -> Promise;
+    /// Logs the DAO transfer result after unclaimed fees are swept.
     fn on_ft_transfer_to_dao_callback(&mut self);
 }
 
@@ -86,6 +89,7 @@ impl Market {
     }
 
     #[private]
+    /// Stores the amount paid to the market creator after the collateral transfer callback succeeds.
     pub fn on_claim_market_creator_fees_resolved_callback(&mut self, payee: AccountId) -> String {
         let ft_transfer_result = match env::promise_result(0) {
             PromiseResult::Successful(result) => result,
@@ -150,6 +154,7 @@ impl Market {
         };
     }
 
+    /// Returns the staking-fee amount already claimed by an account, or zero when none is recorded.
     pub fn get_claimed_staking_fees(&self, account_id: AccountId) -> String {
         if let Some(staking_fees) = &self.fees.staking_fees {
             match staking_fees.get(&account_id) {
@@ -161,6 +166,7 @@ impl Market {
         }
     }
 
+    /// Reports whether the fee claiming window has elapsed.
     pub fn is_claiming_window_expired(&self) -> bool {
         if let Some(claiming_window) = self.fees.claiming_window {
             return self.get_block_timestamp() > claiming_window;
@@ -169,6 +175,7 @@ impl Market {
         return false;
     }
 
+    /// Returns the configured fee claiming-window timestamp.
     pub fn claiming_window(&self) -> Timestamp {
         if let Some(claiming_window) = self.fees.claiming_window {
             return claiming_window;

--- a/amm/src/ft_receiver.rs
+++ b/amm/src/ft_receiver.rs
@@ -3,6 +3,7 @@ use near_sdk::{json_types::U128, near_bindgen, serde_json, AccountId, PromiseOrV
 use crate::*;
 
 pub trait FungibleTokenReceiver {
+    /// Handles incoming fungible-token transfers and dispatches the encoded payload.
     fn ft_on_transfer(
         &mut self,
         sender_id: AccountId,

--- a/amm/src/modifiers.rs
+++ b/amm/src/modifiers.rs
@@ -5,48 +5,56 @@ use crate::storage::*;
 
 #[near_bindgen]
 impl Market {
+    /// Panics when the market has already been resolved.
     pub fn assert_is_not_resolved(&self) {
         if self.is_resolved() {
             env::panic_str("ERR_MARKET_RESOLVED");
         }
     }
 
+    /// Panics when the market has not been resolved yet.
     pub fn assert_is_resolved(&self) {
         if !self.is_resolved() {
             env::panic_str("ERR_MARKET_NOT_RESOLVED");
         }
     }
 
+    /// Panics when the market is no longer open for buys.
     pub fn assert_is_open(&self) {
         if !self.is_open() {
             env::panic_str("ERR_MARKET_IS_CLOSED");
         }
     }
 
+    /// Panics when the market resolution window has expired.
     pub fn assert_is_resolution_window_open(&self) {
         if self.is_resolution_window_expired() {
             env::panic_str("ERR_RESOLUTION_WINDOW_EXPIRED");
         }
     }
 
+    /// Panics when the fee claiming window has expired.
     pub fn assert_is_claiming_window_open(&self) {
         if self.is_claiming_window_expired() {
             env::panic_str("ERR_CLAIMING_WINDOW_EXPIRED");
         }
     }
 
+    /// Panics while an expired market is still inside its unresolved resolution period.
     pub fn assert_is_not_under_resolution(&self) {
         if self.is_over() && !self.is_resolved() && !self.is_resolution_window_expired() {
             env::panic_str("ERR_MARKET_IS_UNDER_RESOLUTION");
         }
     }
 
+    /// Panics when the supplied Switchboard instruction does not match the stored owner instruction.
     pub fn assert_only_owner(&self, ix: Ix) {
         if self.resolution.ix.address != ix.address {
             env::panic_str("ERR_SIGNER_IS_NOT_OWNER");
         }
     }
 
+    /// Panics when the supplied outcome id has no stored outcome token.
     pub fn assert_is_valid_outcome(&self, outcome_id: OutcomeId) {
         self.get_outcome_token(outcome_id);
     }

--- a/amm/src/outcome_token.rs
+++ b/amm/src/outcome_token.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 impl Default for OutcomeToken {
+    /// Prevents creating an outcome token without explicit outcome metadata.
     fn default() -> Self {
         panic!("OutcomeToken should be initialized before usage")
     }

--- a/amm/src/views.rs
+++ b/amm/src/views.rs
@@ -7,10 +7,12 @@ use substring::Substring;
 use crate::{storage::*, FORMATTED_STRING_LOCALE};
 
 trait Extract {
+    /// Converts a timestamp value into the nanosecond precision used by market comparisons.
     fn extract_nanoseconds(&self) -> Timestamp;
 }
 
 impl Extract for Timestamp {
+    /// Parses the timestamp prefix used by the existing market window calculations.
     fn extract_nanoseconds(&self) -> Timestamp {
         let timestamp = self.to_string();
         let seconds = timestamp.substring(0, 13);
@@ -21,10 +23,12 @@ impl Extract for Timestamp {
 
 #[near_bindgen]
 impl Market {
+    /// Returns a copy of the market metadata.
     pub fn get_market_data(&self) -> MarketData {
         self.market.clone()
     }
 
+    /// Returns the price-market metadata or panics when the market is not price based.
     pub fn get_pricing_data(&self) -> Pricing {
         match &self.price {
             Some(price) => price.clone(),
@@ -32,14 +36,17 @@ impl Market {
         }
     }
 
+    /// Returns a copy of the resolution metadata.
     pub fn get_resolution_data(&self) -> Resolution {
         self.resolution.clone()
     }
 
+    /// Returns the fee ratio charged when buying outcome tokens.
     pub fn get_fee_ratio(&self) -> WrappedBalance {
         self.fees.fee_ratio
     }
 
+    /// Returns a stored outcome token by id.
     pub fn get_outcome_token(&self, outcome_id: OutcomeId) -> OutcomeToken {
         match self.outcome_tokens.get(&outcome_id) {
             Some(token) => token,
@@ -47,6 +54,7 @@ impl Market {
         }
     }
 
+    /// Returns all outcome ids derived from the configured market options.
     pub fn get_outcome_ids(&self) -> Vec<OutcomeId> {
         self.market
             .options
@@ -56,26 +64,32 @@ impl Market {
             .collect()
     }
 
+    /// Returns the current block timestamp as the contract timestamp type.
     pub fn get_block_timestamp(&self) -> Timestamp {
         env::block_timestamp().try_into().unwrap()
     }
 
+    /// Returns a copy of the collateral-token metadata and balances.
     pub fn get_collateral_token_metadata(&self) -> CollateralToken {
         self.collateral_token.clone()
     }
 
+    /// Returns the account that created the market.
     pub fn get_market_creator_account_id(&self) -> AccountId {
         self.management.market_creator_account_id.clone()
     }
 
+    /// Returns the DAO account configured for this market.
     pub fn dao_account_id(&self) -> AccountId {
         self.management.dao_account_id.clone()
     }
 
+    /// Returns the timestamp when the resolution window closes.
     pub fn resolution_window(&self) -> Timestamp {
         self.resolution.window
     }
 
+    /// Returns the timestamp when the market was resolved.
     pub fn resolved_at(&self) -> Timestamp {
         match self.resolution.resolved_at {
             Some(timestamp) => timestamp,
@@ -83,6 +97,7 @@ impl Market {
         }
     }
 
+    /// Reports whether the market already has a resolution timestamp.
     pub fn is_resolved(&self) -> bool {
         match self.resolution.resolved_at {
             Some(_) => true,
@@ -90,6 +105,7 @@ impl Market {
         }
     }
 
+    /// Returns the timestamp after which buys are disabled and sells may be considered.
     pub fn get_buy_sell_timestamp(&self) -> i64 {
         let diff = (self.market.ends_at - self.market.starts_at) as f64 * 0.25;
 
@@ -106,27 +122,33 @@ impl Market {
         self.get_block_timestamp().extract_nanoseconds() <= limit.extract_nanoseconds()
     }
 
+    /// Reports whether the market is closed for new buys.
     pub fn is_closed(&self) -> bool {
         !self.is_open()
     }
 
+    /// Reports whether the market end timestamp has passed.
     pub fn is_over(&self) -> bool {
         self.get_block_timestamp().extract_nanoseconds() > self.market.ends_at.extract_nanoseconds()
     }
 
+    /// Reports whether the resolution window has passed.
     pub fn is_resolution_window_expired(&self) -> bool {
         self.get_block_timestamp().extract_nanoseconds()
             > self.resolution.window.extract_nanoseconds()
     }
 
+    /// Reports whether the market passed resolution without a winning outcome.
     pub fn is_expired_unresolved(&self) -> bool {
         self.is_resolution_window_expired() && !self.is_resolved()
     }
 
+    /// Returns an account's balance for a specific outcome token.
     pub fn balance_of(&self, outcome_id: OutcomeId, account_id: AccountId) -> WrappedBalance {
         self.get_outcome_token(outcome_id).get_balance(&account_id)
     }
 
+    /// Splits a buy amount into mintable outcome tokens and collected fees.
     pub fn get_amount_mintable(&self, amount: WrappedBalance) -> (WrappedBalance, WrappedBalance) {
         let fee = self.calc_percentage(amount, self.get_fee_ratio());
         let amount_mintable = amount - fee;
@@ -134,6 +156,7 @@ impl Market {
         (amount_mintable, fee)
     }
 
+    /// Calculates the collateral payable and proportional weight for selling outcome tokens.
     pub fn get_amount_payable(
         &self,
         amount: WrappedBalance,
@@ -204,6 +227,7 @@ impl Market {
         (amount_payable, weight)
     }
 
+    /// Returns the fixed-point precision derived from collateral token decimals.
     pub fn get_precision_decimals(&self) -> WrappedBalance {
         let precision = format!(
             "{:0<p$}",
@@ -214,6 +238,7 @@ impl Market {
         precision.parse().unwrap()
     }
 
+    /// Calculates a basis-point percentage using the market's fixed-point precision.
     pub fn calc_percentage(&self, amount: WrappedBalance, bps: WrappedBalance) -> WrappedBalance {
         math::complex_div_u128(
             self.get_precision_decimals(),

--- a/feed-parser/src/callbacks.rs
+++ b/feed-parser/src/callbacks.rs
@@ -6,12 +6,14 @@ use crate::storage::*;
 
 #[ext_contract(ext_market)]
 trait Market {
+    /// Resolves the calling market with the winning outcome returned by the feed parser.
     fn resolve(&mut self, outcome_id: u64, ix: Ix);
 }
 
 #[near_bindgen]
 impl SwitchboardFeedParser {
     #[private]
+    /// Handles a Switchboard aggregator response and forwards the winning outcome to the market.
     pub fn on_internal_above_price_feed_read_callback(
         &self,
         payload: AbovePriceFeedArgs,

--- a/feed-parser/src/contract.rs
+++ b/feed-parser/src/contract.rs
@@ -7,11 +7,13 @@ use crate::storage::*;
 
 #[ext_contract(ext_self)]
 trait Callbacks {
+    /// Receives the result of an internal above-price feed read.
     fn on_internal_above_price_feed_read_callback(&self, payload: AbovePriceFeedArgs);
 }
 
 #[near_bindgen]
 impl SwitchboardFeedParser {
+    /// Parses an aggregator-read payload and starts the matching feed read flow.
     pub fn aggregator_read(&self, msg: String) -> Promise {
         let payload: Payload =
             serde_json::from_str(&msg).expect("ERR_AGGREGATOR_READ_INVALID_PAYLOAD");
@@ -28,6 +30,7 @@ impl SwitchboardFeedParser {
 }
 
 impl SwitchboardFeedParser {
+    /// Calls the Switchboard program to read the aggregator identified by the instruction.
     fn internal_aggregator_read(&self, ix: &Ix) -> Promise {
         Promise::new(SWITCHBOARD_PROGRAM_ID.parse().unwrap()).function_call(
             "aggregator_read".into(),
@@ -45,6 +48,7 @@ impl SwitchboardFeedParser {
         )
     }
 
+    /// Validates a binary above-price market payload and chains the aggregator callback.
     fn internal_above_price_feed_read(&self, payload: AbovePriceFeedArgs) -> Promise {
         if payload.market_options[0] != "yes" {
             env::panic_str("ERR_INVALID_MARKET_OPTIONS");

--- a/market-factory/src/callbacks.rs
+++ b/market-factory/src/callbacks.rs
@@ -6,6 +6,7 @@ use crate::storage::*;
 #[near_bindgen]
 impl MarketFactory {
     #[private]
+    /// Continues market creation by creating outcome tokens and registering collateral-token storage.
     pub fn on_create_market_callback(
         &mut self,
         market_account_id: AccountId,
@@ -55,6 +56,7 @@ impl MarketFactory {
     }
 
     #[private]
+    /// Finalizes market registration once outcome-token creation and collateral storage deposit succeed.
     pub fn on_create_outcome_tokens_ft_storage_deposit_callback(
         &mut self,
         market_account_id: AccountId,

--- a/market-factory/src/contract.rs
+++ b/market-factory/src/contract.rs
@@ -9,6 +9,7 @@ use crate::storage::*;
 
 #[ext_contract(ext_self)]
 trait Callbacks {
+    /// Continues market setup after the market subaccount is created and initialized.
     fn on_create_market_callback(
         &mut self,
         market_account_id: AccountId,
@@ -17,6 +18,7 @@ trait Callbacks {
 }
 
 impl Default for MarketFactory {
+    /// Prevents using the factory before explicit initialization.
     fn default() -> Self {
         env::panic_str("MarketFactory should be initialized before usage")
     }
@@ -25,6 +27,7 @@ impl Default for MarketFactory {
 #[near_bindgen]
 impl MarketFactory {
     #[init]
+    /// Initializes an empty factory with no tracked markets.
     pub fn new() -> Self {
         if env::state_exists() {
             env::panic_str("ERR_ALREADY_INITIALIZED");
@@ -36,6 +39,7 @@ impl MarketFactory {
     }
 
     #[payable]
+    /// Creates a market subaccount, deploys the market contract, and schedules post-deploy setup.
     pub fn create_market(&mut self, name: AccountId, args: Base64VecU8) -> Promise {
         let market_account_id: AccountId = format!("{}.{}", name, env::current_account_id())
             .parse()

--- a/market-factory/src/views.rs
+++ b/market-factory/src/views.rs
@@ -4,14 +4,17 @@ use crate::storage::*;
 
 #[near_bindgen]
 impl MarketFactory {
+    /// Returns every market account tracked by the factory.
     pub fn get_markets_list(&self) -> Vec<AccountId> {
         self.markets.to_vec()
     }
 
+    /// Returns the number of markets tracked by the factory.
     pub fn get_markets_count(&self) -> u64 {
         self.markets.len()
     }
 
+    /// Returns a paginated slice of tracked market accounts.
     pub fn get_markets(&self, from_index: u64, limit: u64) -> Vec<AccountId> {
         let elements = self.markets.as_vector();
 


### PR DESCRIPTION
Closes #32

## Summary
- Add documentation comments to the contract-facing methods across AMM, feed-parser, and market-factory crates.
- Cover callback traits, public near-bindgen methods, internal helpers, view methods, modifiers, and token helpers.
- Keep this as a documentation-only change with no runtime logic changes.

## Validation
- Method documentation scan: 0 undocumented non-test Rust methods
- `cargo fmt -- --check` in `amm`, `feed-parser`, `market-factory`, and `shared`
- `cargo check` in `amm`, `feed-parser`, `market-factory`, and `shared`
- `git diff --check`

## Payout
USDT on Polygon PoS: 0xE7201960FEa5bFF7Ae4Fe3286093dCedabeDB003
